### PR TITLE
missing header in io.cpp

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -14,6 +14,7 @@
 
 
 #include <iostream>
+#include <iomanip>
 #include <string>
 #include <vector>
 #include <fstream>


### PR DESCRIPTION
std::setprecision requires iomanip header